### PR TITLE
Resolve api shutdown after start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-tomcat</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>


### PR DESCRIPTION
Fixes the issue where the API was shutting down immediately after startup. This was resolved by removing the spring-boot-starter-tomcat dependency.