### PR TITLE
Create getters and setters in ClientMessageError

### DIFF
--- a/src/main/java/com/es/boardGameTraining/util/exception/ClientMessageError.java
+++ b/src/main/java/com/es/boardGameTraining/util/exception/ClientMessageError.java
@@ -9,4 +9,19 @@ public class ClientMessageError {
         this.uri = uri;
     }
 
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
 }


### PR DESCRIPTION
Create getters and setters in ClientMessageError so that errors are displayed correctly in APIExceptionHandler